### PR TITLE
Publish metrics only for containers

### DIFF
--- a/src/fty_alert_stats_actor.cc
+++ b/src/fty_alert_stats_actor.cc
@@ -251,31 +251,39 @@ void AlertStatsActor::sendMetric(AlertCounts::value_type &metric, bool recursive
         return;
     }
 
-    metric.second.lastSent = zclock_time()/1000;
+    // Inhibit metrics for simple devices or fty-outage malfunctions
+    const auto& assetId = metric.first;
 
-    zmsg_t *msg;
+    if (assetId.find("datacenter-") == 0 || assetId.find("room-") == 0 || assetId.find("row-") == 0 || assetId.find("rack-") == 0) {
+        metric.second.lastSent = zclock_time()/1000;
 
-    msg = fty_proto_encode_metric(
-        nullptr,
-        metric.second.lastSent,
-        m_metricTTL,
-        WARNING_METRIC,
-        metric.first.c_str(),
-        std::to_string(metric.second.warning).c_str(),
-        "");
+        zmsg_t *msg;
 
-    mlm_client_send(m_client, (std::string(WARNING_METRIC)+"@"+metric.first).c_str(), &msg);
+        msg = fty_proto_encode_metric(
+            nullptr,
+            metric.second.lastSent,
+            m_metricTTL,
+            WARNING_METRIC,
+            assetId.c_str(),
+            std::to_string(metric.second.warning).c_str(),
+            "");
 
-    msg = fty_proto_encode_metric(
-        nullptr,
-        metric.second.lastSent,
-        m_metricTTL,
-        CRITICAL_METRIC,
-        metric.first.c_str(),
-        std::to_string(metric.second.critical).c_str(),
-        "");
+        mlm_client_send(m_client, (std::string(WARNING_METRIC)+"@"+assetId).c_str(), &msg);
 
-    mlm_client_send(m_client, (std::string(CRITICAL_METRIC)+"@"+metric.first).c_str(), &msg);
+        msg = fty_proto_encode_metric(
+            nullptr,
+            metric.second.lastSent,
+            m_metricTTL,
+            CRITICAL_METRIC,
+            assetId.c_str(),
+            std::to_string(metric.second.critical).c_str(),
+            "");
+
+        mlm_client_send(m_client, (std::string(CRITICAL_METRIC)+"@"+assetId).c_str(), &msg);
+    }
+    else {
+        metric.second.lastSent = INT64_MAX/2;
+    }
 
     if (recursive) {
         // Recursively send metric of parent

--- a/src/fty_alert_stats_server.cc
+++ b/src/fty_alert_stats_server.cc
@@ -130,8 +130,8 @@ fty_alert_stats_server_test (bool verbose)
                 fty_proto_encode_alert(nullptr, zclock_time()/1000, 60, "alert1@rackcontroller-0", "rackcontroller-0", "ACTIVE", "WARNING", "", nullptr)
             },
             {
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-0", "1", ""),
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-0", "0", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-0", "1", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-0", "0", ""),
                 fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "datacenter-3", "1", ""),
                 fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "datacenter-3", "0", "")
             },
@@ -174,8 +174,8 @@ fty_alert_stats_server_test (bool verbose)
                 fty_proto_encode_alert(nullptr, zclock_time()/1000, 60, "alert1@rackcontroller-0", "rackcontroller-0", "RESOLVED", "WARNING", "", nullptr)
             },
             {
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-0", "0", ""),
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-0", "0", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-0", "0", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-0", "0", ""),
                 fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "datacenter-3", "1", ""),
                 fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "datacenter-3", "1", "")
             },
@@ -245,8 +245,8 @@ fty_alert_stats_server_test (bool verbose)
                 fty_proto_encode_alert(nullptr, zclock_time()/1000, 60, "alert1@rackcontroller-0", "rackcontroller-0", "ACTIVE", "WARNING", "", nullptr)
             },
             {
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-0", "1", ""),
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-0", "0", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-0", "1", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-0", "0", ""),
                 fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "datacenter-3", "1", ""),
                 fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "datacenter-3", "0", "")
             },
@@ -259,10 +259,10 @@ fty_alert_stats_server_test (bool verbose)
             },
             {},
             {
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-1", "0", ""),
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-1", "0", "")
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-1", "0", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-1", "0", "")
             },
-            TestCase::Action::CHECK_METRICS
+            TestCase::Action::CHECK_NO_METRICS
         },
         {
             "Publish WARNING alert1@rackcontroller-2 (unknown asset)",
@@ -271,10 +271,10 @@ fty_alert_stats_server_test (bool verbose)
                 fty_proto_encode_alert(nullptr, zclock_time()/1000, 60, "alert1@rackcontroller-2", "rackcontroller-2", "ACTIVE", "WARNING", "", nullptr)
             },
             {
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-2", "1", ""),
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-2", "0", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-2", "1", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-2", "0", ""),
             },
-            TestCase::Action::CHECK_METRICS
+            TestCase::Action::CHECK_NO_METRICS
         },
         {
             "Create rackcontroller-2 (with known alerts)",
@@ -283,8 +283,8 @@ fty_alert_stats_server_test (bool verbose)
             },
             {},
             {
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-2", "1", ""),
-                fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-2", "0", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "rackcontroller-2", "1", ""),
+                //fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "rackcontroller-2", "0", ""),
                 fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::WARNING_METRIC, "datacenter-3", "2", ""),
                 fty_proto_encode_metric(nullptr, 0, 0, AlertStatsActor::CRITICAL_METRIC, "datacenter-3", "0", "")
             },


### PR DESCRIPTION
fty-outage would be tricked into thinking all is well if we publish metrics on all assets.