### PR TITLE
Fix spelling of "fty_shm" (should be "fty-shm")

### DIFF
--- a/builds/check_zproject/ci_build.sh
+++ b/builds/check_zproject/ci_build.sh
@@ -16,7 +16,7 @@ git clone --quiet --depth 1 -b 1.0-FTY-master https://github.com/42ity/malamute.
 git clone --quiet --depth 1 -b 1.1.2-FTY-master https://github.com/42ity/log4cplus.git log4cplus
 git clone --quiet --depth 1 -b master https://github.com/42ity/fty-common-logging.git fty-common-logging
 git clone --quiet --depth 1 -b master https://github.com/42ity/fty-proto.git fty-proto
-git clone --quiet --depth 1 -b master https://github.com/42ity/fty-shm.git fty_shm
+git clone --quiet --depth 1 -b master https://github.com/42ity/fty-shm.git fty-shm
 git clone --quiet --depth 1 -b 2.2-FTY-master https://github.com/42ity/cxxtools.git cxxtools
 git clone --quiet --depth 1 -b master https://github.com/42ity/fty-common.git fty-common
 git clone --quiet --depth 1 -b master https://github.com/42ity/fty-common-mlm.git fty-common-mlm

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -412,16 +412,16 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         cd "${BASE_PWD}"
     fi
 
-    # Start of recipe for dependency: fty_shm
+    # Start of recipe for dependency: fty-shm
     if ! (command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list libfty_shm-dev >/dev/null 2>&1) || \
-           (command -v brew >/dev/null 2>&1 && brew ls --versions fty_shm >/dev/null 2>&1) \
+           (command -v brew >/dev/null 2>&1 && brew ls --versions fty-shm >/dev/null 2>&1) \
     ; then
         echo ""
         BASE_PWD=${PWD}
-        echo "`date`: INFO: Building prerequisite 'fty_shm' from Git repository..." >&2
+        echo "`date`: INFO: Building prerequisite 'fty-shm' from Git repository..." >&2
         cd ./tmp-deps
-        $CI_TIME git clone --quiet --depth 1 -b master https://github.com/42ity/fty-shm.git fty_shm
-        cd ./fty_shm
+        $CI_TIME git clone --quiet --depth 1 -b master https://github.com/42ity/fty-shm.git fty-shm
+        cd ./fty-shm
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR
         git --no-pager log --oneline -n1

--- a/configure.ac
+++ b/configure.ac
@@ -803,7 +803,7 @@ AS_IF([test x"${search_libfty_shm}" = xyes], [
                 )
         fi
 
-        AC_CHECK_LIB([fty_shm], [fty_shm_test],
+        AC_CHECK_LIB([fty-shm], [fty_shm_test],
             [
                 was_fty_shm_check_lib_detected=yes
                 PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -lfty_shm"

--- a/packaging/redhat/fty-alert-stats.spec
+++ b/packaging/redhat/fty-alert-stats.spec
@@ -62,7 +62,7 @@ BuildRequires:  malamute-devel >= 1.0.0
 BuildRequires:  log4cplus-devel
 BuildRequires:  fty-common-logging-devel
 BuildRequires:  fty-proto-devel >= 1.0.0
-BuildRequires:  fty_shm-devel >= 1.0.0
+BuildRequires:  fty-shm-devel >= 1.0.0
 BuildRequires:  cxxtools-devel
 BuildRequires:  openssl-devel
 BuildRequires:  fty-common-devel

--- a/project.xml
+++ b/project.xml
@@ -121,7 +121,8 @@
         </use>
     </use>
 
-    <use project = "fty_shm"
+    <use project = "fty-shm"
+        linkname = "fty_shm"
         libname = "libfty_shm"
         header="fty_shm.h" min_major = "1"
         test = "fty_shm_test"


### PR DESCRIPTION
To replicate in a dozen other components...

See also question https://github.com/zeromq/zproject/issues/1207 that I stumbled on during this work.